### PR TITLE
Community Edition More Thingsboard 3.1 REST API Compatible (limit/page_size/page)

### DIFF
--- a/tb_rest_client/api/api_ce/alarm_controller_api.py
+++ b/tb_rest_client/api/api_ce/alarm_controller_api.py
@@ -499,20 +499,24 @@ class AlarmControllerApi(object):
             _request_timeout=params.get('_request_timeout'),
             collection_formats=collection_formats)
 
-    def get_alarms_using_get(self, entity_type, entity_id, limit, **kwargs):  # noqa: E501
+    def get_alarms_using_get(self, entity_type, entity_id, page_size, page, **kwargs):  # noqa: E501
         """getAlarms  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
-        >>> thread = api_pe.get_alarms_using_get(entity_type, entity_id, limit, async_req=True)
+        >>> thread = api_pe.get_alarms_using_get(entity_type, entity_id, page_size, page, async_req=True)
         >>> result = thread.get()
 
         :param async_req bool
         :param str entity_type: entityType (required)
         :param str entity_id: entityId (required)
-        :param int limit: limit (required)
         :param str search_status: searchStatus
         :param str status: status
+        :param str page_size: pageSize (required)
+        :param str page: page (required)
+        :param str text_search: textSearch
+        :param str sort_property: sortProperty
+        :param str sort_order: sortOrder
         :param int start_time: startTime
         :param int end_time: endTime
         :param bool asc_order: ascOrder
@@ -524,25 +528,29 @@ class AlarmControllerApi(object):
         """
         kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
-            return self.get_alarms_using_get_with_http_info(entity_type, entity_id, limit, **kwargs)  # noqa: E501
+            return self.get_alarms_using_get_with_http_info(entity_type, entity_id, page_size, page, **kwargs)  # noqa: E501
         else:
-            (data) = self.get_alarms_using_get_with_http_info(entity_type, entity_id, limit, **kwargs)  # noqa: E501
+            (data) = self.get_alarms_using_get_with_http_info(entity_type, entity_id, page_size, page, **kwargs)  # noqa: E501
             return data
 
-    def get_alarms_using_get_with_http_info(self, entity_type, entity_id, limit, **kwargs):  # noqa: E501
+    def get_alarms_using_get_with_http_info(self, entity_type, entity_id, page_size, page, **kwargs):  # noqa: E501
         """getAlarms  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
-        >>> thread = api_pe.get_alarms_using_get_with_http_info(entity_type, entity_id, limit, async_req=True)
+        >>> thread = api_pe.get_alarms_using_get_with_http_info(entity_type, entity_id, page_size, page, async_req=True)
         >>> result = thread.get()
 
         :param async_req bool
         :param str entity_type: entityType (required)
         :param str entity_id: entityId (required)
-        :param int limit: limit (required)
         :param str search_status: searchStatus
         :param str status: status
+        :param str page_size: pageSize (required)
+        :param str page: page (required)
+        :param str text_search: textSearch
+        :param str sort_property: sortProperty
+        :param str sort_order: sortOrder
         :param int start_time: startTime
         :param int end_time: endTime
         :param bool asc_order: ascOrder
@@ -553,7 +561,7 @@ class AlarmControllerApi(object):
                  returns the request thread.
         """
 
-        all_params = ['entity_type', 'entity_id', 'limit', 'search_status', 'status', 'start_time', 'end_time', 'asc_order', 'offset', 'fetch_originator']  # noqa: E501
+        all_params = ['entity_type', 'entity_id', 'search_status', 'status', 'page_size', 'page', 'text_search', 'sort_property', 'sort_order', 'start_time', 'end_time', 'asc_order', 'offset', 'fetch_originator']  # noqa: E501
         all_params.append('async_req')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
@@ -572,10 +580,14 @@ class AlarmControllerApi(object):
         if ('entity_id' not in params or
                 params['entity_id'] is None):
             raise ValueError("Missing the required parameter `entity_id` when calling `get_alarms_using_get`")  # noqa: E501
-        # verify the required parameter 'limit' is set
-        if ('limit' not in params or
-                params['limit'] is None):
-            raise ValueError("Missing the required parameter `limit` when calling `get_alarms_using_get`")  # noqa: E501
+        # verify the required parameter 'page_size' is set
+        if ('page_size' not in params or
+                params['page_size'] is None):
+            raise ValueError("Missing the required parameter `page_size` when calling `get_alarms_using_get`")  # noqa: E501
+        # verify the required parameter 'page' is set
+        if ('page' not in params or
+                params['page'] is None):
+            raise ValueError("Missing the required parameter `page` when calling `get_alarms_using_get`")  # noqa: E501
 
         collection_formats = {}
 
@@ -590,8 +602,16 @@ class AlarmControllerApi(object):
             query_params.append(('searchStatus', params['search_status']))  # noqa: E501
         if 'status' in params:
             query_params.append(('status', params['status']))  # noqa: E501
-        if 'limit' in params:
-            query_params.append(('limit', params['limit']))  # noqa: E501
+        if 'page_size' in params:
+            query_params.append(('pageSize', params['page_size']))  # noqa: E501
+        if 'page' in params:
+            query_params.append(('page', params['page']))  # noqa: E501
+        if 'text_search' in params:
+            query_params.append(('textSearch', params['text_search']))  # noqa: E501
+        if 'sort_property' in params:
+            query_params.append(('sortProperty', params['sort_property']))  # noqa: E501
+        if 'sort_order' in params:
+            query_params.append(('sortOrder', params['sort_order']))  # noqa: E501
         if 'start_time' in params:
             query_params.append(('startTime', params['start_time']))  # noqa: E501
         if 'end_time' in params:
@@ -621,7 +641,7 @@ class AlarmControllerApi(object):
         auth_settings = ['X-Authorization']  # noqa: E501
 
         return self.api_client.call_api(
-            '/api/alarm/{entityType}/{entityId}{?searchStatus,status,limit,startTime,endTime,ascOrder,offset,fetchOriginator}', 'GET',
+            '/api/alarm/{entityType}/{entityId}{?searchStatus,status,pageSize,page,textSearch,sortProperty,sortOrder,startTime,endTime,offset,fetchOriginator}', 'GET',
             path_params,
             query_params,
             header_params,

--- a/tb_rest_client/api/api_ce/asset_controller_api.py
+++ b/tb_rest_client/api/api_ce/asset_controller_api.py
@@ -685,53 +685,55 @@ class AssetControllerApi(object):
             _request_timeout=params.get('_request_timeout'),
             collection_formats=collection_formats)
 
-    def get_customer_assets_using_get(self, customer_id, limit, **kwargs):  # noqa: E501
+    def get_customer_assets_using_get(self, customer_id, page_size, page, **kwargs):  # noqa: E501
         """getCustomerAssets  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
-        >>> thread = api_pe.get_customer_assets_using_get(customer_id, limit, async_req=True)
+        >>> thread = api_pe.get_customer_assets_using_get(customer_id, page_size, page, async_req=True)
         >>> result = thread.get()
 
         :param async_req bool
         :param str customer_id: customerId (required)
-        :param str limit: limit (required)
         :param str type: type
         :param str text_search: textSearch
-        :param str id_offset: idOffset
-        :param str text_offset: textOffset
+        :param str sort_property: sortProperty
+        :param str sort_order: sortOrder
+        :param str page_size: pageSize (required)
+        :param str page: page (required)
         :return: TextPageDataAsset
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
-            return self.get_customer_assets_using_get_with_http_info(customer_id, limit, **kwargs)  # noqa: E501
+            return self.get_customer_assets_using_get_with_http_info(customer_id, page_size, page, **kwargs)  # noqa: E501
         else:
-            (data) = self.get_customer_assets_using_get_with_http_info(customer_id, limit, **kwargs)  # noqa: E501
+            (data) = self.get_customer_assets_using_get_with_http_info(customer_id, page_size, page, **kwargs)  # noqa: E501
             return data
 
-    def get_customer_assets_using_get_with_http_info(self, customer_id, limit, **kwargs):  # noqa: E501
+    def get_customer_assets_using_get_with_http_info(self, customer_id, page_size, page, **kwargs):  # noqa: E501
         """getCustomerAssets  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
-        >>> thread = api_pe.get_customer_assets_using_get_with_http_info(customer_id, limit, async_req=True)
+        >>> thread = api_pe.get_customer_assets_using_get_with_http_info(customer_id, page_size, page, async_req=True)
         >>> result = thread.get()
 
         :param async_req bool
         :param str customer_id: customerId (required)
-        :param str limit: limit (required)
         :param str type: type
         :param str text_search: textSearch
-        :param str id_offset: idOffset
-        :param str text_offset: textOffset
+        :param str sort_property: sortProperty
+        :param str sort_order: sortOrder
+        :param str page_size: pageSize (required)
+        :param str page: page (required)
         :return: TextPageDataAsset
                  If the method is called asynchronously,
                  returns the request thread.
         """
 
-        all_params = ['customer_id', 'limit', 'type', 'text_search', 'id_offset', 'text_offset']  # noqa: E501
+        all_params = ['customer_id', 'type', 'text_search', 'sort_property', 'sort_order', 'page_size', 'page']  # noqa: E501
         all_params.append('async_req')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
@@ -746,10 +748,14 @@ class AssetControllerApi(object):
         if ('customer_id' not in params or
                 params['customer_id'] is None):
             raise ValueError("Missing the required parameter `customer_id` when calling `get_customer_assets_using_get`")  # noqa: E501
-        # verify the required parameter 'limit' is set
-        if ('limit' not in params or
-                params['limit'] is None):
-            raise ValueError("Missing the required parameter `limit` when calling `get_customer_assets_using_get`")  # noqa: E501
+        # verify the required parameter 'page_size' is set
+        if ('page_size' not in params or
+                params['page_size'] is None):
+            raise ValueError("Missing the required parameter `page_size` when calling `get_customer_assets_using_get`")  # noqa: E501
+        # verify the required parameter 'page' is set
+        if ('page' not in params or
+                params['page'] is None):
+            raise ValueError("Missing the required parameter `page` when calling `get_customer_assets_using_get`")  # noqa: E501
 
         collection_formats = {}
 
@@ -762,12 +768,14 @@ class AssetControllerApi(object):
             query_params.append(('type', params['type']))  # noqa: E501
         if 'text_search' in params:
             query_params.append(('textSearch', params['text_search']))  # noqa: E501
-        if 'id_offset' in params:
-            query_params.append(('idOffset', params['id_offset']))  # noqa: E501
-        if 'text_offset' in params:
-            query_params.append(('textOffset', params['text_offset']))  # noqa: E501
-        if 'limit' in params:
-            query_params.append(('limit', params['limit']))  # noqa: E501
+        if 'sort_property' in params:
+            query_params.append(('sortProperty', params['sort_property']))  # noqa: E501
+        if 'sort_order' in params:
+            query_params.append(('sortOrder', params['sort_order']))  # noqa: E501
+        if 'page_size' in params:
+            query_params.append(('pageSize', params['page_size']))  # noqa: E501
+        if 'page' in params:
+            query_params.append(('page', params['page']))  # noqa: E501
 
         header_params = {}
 
@@ -787,7 +795,7 @@ class AssetControllerApi(object):
         auth_settings = ['X-Authorization']  # noqa: E501
 
         return self.api_client.call_api(
-            '/api/customer/{customerId}/assets{?type,textSearch,idOffset,textOffset,limit}', 'GET',
+            '/api/customer/{customerId}/assets{?type,textSearch,sortProperty,sortOrder,pageSize,page}', 'GET',
             path_params,
             query_params,
             header_params,
@@ -895,51 +903,53 @@ class AssetControllerApi(object):
             _request_timeout=params.get('_request_timeout'),
             collection_formats=collection_formats)
 
-    def get_tenant_assets_using_get(self, limit, **kwargs):  # noqa: E501
+    def get_tenant_assets_using_get(self, page_size, page, **kwargs):  # noqa: E501
         """getTenantAssets  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
-        >>> thread = api_pe.get_tenant_assets_using_get(limit, async_req=True)
+        >>> thread = api_pe.get_tenant_assets_using_get(page_size, page, async_req=True)
         >>> result = thread.get()
 
         :param async_req bool
-        :param str limit: limit (required)
         :param str type: type
         :param str text_search: textSearch
-        :param str id_offset: idOffset
-        :param str text_offset: textOffset
+        :param str sort_property: sortProperty
+        :param str sort_order: sortOrder
+        :param str page_size: pageSize (required)
+        :param str page: page (required)
         :return: TextPageDataAsset
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
-            return self.get_tenant_assets_using_get_with_http_info(limit, **kwargs)  # noqa: E501
+            return self.get_tenant_assets_using_get_with_http_info(page_size, page, **kwargs)  # noqa: E501
         else:
-            (data) = self.get_tenant_assets_using_get_with_http_info(limit, **kwargs)  # noqa: E501
+            (data) = self.get_tenant_assets_using_get_with_http_info(page_size, page, **kwargs)  # noqa: E501
             return data
 
-    def get_tenant_assets_using_get_with_http_info(self, limit, **kwargs):  # noqa: E501
+    def get_tenant_assets_using_get_with_http_info(self, page_size, page, **kwargs):  # noqa: E501
         """getTenantAssets  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
-        >>> thread = api_pe.get_tenant_assets_using_get_with_http_info(limit, async_req=True)
+        >>> thread = api_pe.get_tenant_assets_using_get_with_http_info(page_size, page, async_req=True)
         >>> result = thread.get()
 
         :param async_req bool
-        :param str limit: limit (required)
         :param str type: type
         :param str text_search: textSearch
-        :param str id_offset: idOffset
-        :param str text_offset: textOffset
+        :param str sort_property: sortProperty
+        :param str sort_order: sortOrder
+        :param str page_size: pageSize (required)
+        :param str page: page (required)
         :return: TextPageDataAsset
                  If the method is called asynchronously,
                  returns the request thread.
         """
 
-        all_params = ['limit', 'type', 'text_search', 'id_offset', 'text_offset']  # noqa: E501
+        all_params = ['type', 'text_search', 'sort_property', 'sort_order', 'page_size', 'page']  # noqa: E501
         all_params.append('async_req')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
@@ -950,10 +960,14 @@ class AssetControllerApi(object):
             
             params[key] = val
         del params['kwargs']
-        # verify the required parameter 'limit' is set
-        if ('limit' not in params or
-                params['limit'] is None):
-            raise ValueError("Missing the required parameter `limit` when calling `get_tenant_assets_using_get`")  # noqa: E501
+        # verify the required parameter 'page_size' is set
+        if ('page_size' not in params or
+                params['page_size'] is None):
+            raise ValueError("Missing the required parameter `page_size` when calling `get_tenant_assets_using_get`")  # noqa: E501
+        # verify the required parameter 'page' is set
+        if ('page' not in params or
+                params['page'] is None):
+            raise ValueError("Missing the required parameter `page` when calling `get_tenant_assets_using_get`")  # noqa: E501
 
         collection_formats = {}
 
@@ -964,12 +978,14 @@ class AssetControllerApi(object):
             query_params.append(('type', params['type']))  # noqa: E501
         if 'text_search' in params:
             query_params.append(('textSearch', params['text_search']))  # noqa: E501
-        if 'id_offset' in params:
-            query_params.append(('idOffset', params['id_offset']))  # noqa: E501
-        if 'text_offset' in params:
-            query_params.append(('textOffset', params['text_offset']))  # noqa: E501
-        if 'limit' in params:
-            query_params.append(('limit', params['limit']))  # noqa: E501
+        if 'sort_property' in params:
+            query_params.append(('sortProperty', params['sort_property']))  # noqa: E501
+        if 'sort_order' in params:
+            query_params.append(('sortOrder', params['sort_order']))  # noqa: E501
+        if 'page_size' in params:
+            query_params.append(('pageSize', params['page_size']))  # noqa: E501
+        if 'page' in params:
+            query_params.append(('page', params['page']))  # noqa: E501
 
         header_params = {}
 
@@ -989,7 +1005,7 @@ class AssetControllerApi(object):
         auth_settings = ['X-Authorization']  # noqa: E501
 
         return self.api_client.call_api(
-            '/api/tenant/assets{?type,textSearch,idOffset,textOffset,limit}', 'GET',
+            '/api/tenant/assets{?type,textSearch,sortProperty,sortOrder,pageSize,page}', 'GET',
             path_params,
             query_params,
             header_params,

--- a/tb_rest_client/api/api_ce/customer_controller_api.py
+++ b/tb_rest_client/api/api_ce/customer_controller_api.py
@@ -313,49 +313,51 @@ class CustomerControllerApi(object):
             _request_timeout=params.get('_request_timeout'),
             collection_formats=collection_formats)
 
-    def get_customers_using_get(self, limit, **kwargs):  # noqa: E501
+    def get_customers_using_get(self, page_size, page, **kwargs):  # noqa: E501
         """getCustomers  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
-        >>> thread = api_pe.get_customers_using_get(limit, async_req=True)
+        >>> thread = api_pe.get_customers_using_get(page_size, page, async_req=True)
         >>> result = thread.get()
 
         :param async_req bool
-        :param str limit: limit (required)
         :param str text_search: textSearch
-        :param str id_offset: idOffset
-        :param str text_offset: textOffset
+        :param str sort_property: sortProperty
+        :param str sort_order: sortOrder
+        :param str page_size: pageSize (required)
+        :param str page: page (required)
         :return: TextPageDataCustomer
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
-            return self.get_customers_using_get_with_http_info(limit, **kwargs)  # noqa: E501
+            return self.get_customers_using_get_with_http_info(page_size, page, **kwargs)  # noqa: E501
         else:
-            (data) = self.get_customers_using_get_with_http_info(limit, **kwargs)  # noqa: E501
+            (data) = self.get_customers_using_get_with_http_info(page_size, page, **kwargs)  # noqa: E501
             return data
 
-    def get_customers_using_get_with_http_info(self, limit, **kwargs):  # noqa: E501
+    def get_customers_using_get_with_http_info(self, page_size, page, **kwargs):  # noqa: E501
         """getCustomers  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
-        >>> thread = api_pe.get_customers_using_get_with_http_info(limit, async_req=True)
+        >>> thread = api_pe.get_customers_using_get_with_http_info(page_size, page, async_req=True)
         >>> result = thread.get()
 
         :param async_req bool
-        :param str limit: limit (required)
         :param str text_search: textSearch
-        :param str id_offset: idOffset
-        :param str text_offset: textOffset
+        :param str sort_property: sortProperty
+        :param str sort_order: sortOrder
+        :param str page_size: pageSize (required)
+        :param str page: page (required)
         :return: TextPageDataCustomer
                  If the method is called asynchronously,
                  returns the request thread.
         """
 
-        all_params = ['limit', 'text_search', 'id_offset', 'text_offset']  # noqa: E501
+        all_params = ['text_search', 'sort_property', 'sort_order', 'page_size', 'page']  # noqa: E501
         all_params.append('async_req')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
@@ -366,10 +368,14 @@ class CustomerControllerApi(object):
             
             params[key] = val
         del params['kwargs']
-        # verify the required parameter 'limit' is set
-        if ('limit' not in params or
-                params['limit'] is None):
-            raise ValueError("Missing the required parameter `limit` when calling `get_customers_using_get`")  # noqa: E501
+        # verify the required parameter 'page_size' is set
+        if ('page_size' not in params or
+                params['page_size'] is None):
+            raise ValueError("Missing the required parameter `page_size` when calling `get_customers_using_get`")  # noqa: E501
+        # verify the required parameter 'page' is set
+        if ('page' not in params or
+                params['page'] is None):
+            raise ValueError("Missing the required parameter `page` when calling `get_customers_using_get`")  # noqa: E501
 
         collection_formats = {}
 
@@ -378,12 +384,14 @@ class CustomerControllerApi(object):
         query_params = []
         if 'text_search' in params:
             query_params.append(('textSearch', params['text_search']))  # noqa: E501
-        if 'id_offset' in params:
-            query_params.append(('idOffset', params['id_offset']))  # noqa: E501
-        if 'text_offset' in params:
-            query_params.append(('textOffset', params['text_offset']))  # noqa: E501
-        if 'limit' in params:
-            query_params.append(('limit', params['limit']))  # noqa: E501
+        if 'sort_property' in params:
+            query_params.append(('sortProperty', params['sort_property']))  # noqa: E501
+        if 'sort_order' in params:
+            query_params.append(('sortOrder', params['sort_order']))  # noqa: E501
+        if 'page_size' in params:
+            query_params.append(('pageSize', params['page_size']))  # noqa: E501
+        if 'page' in params:
+            query_params.append(('page', params['page']))  # noqa: E501
 
         header_params = {}
 
@@ -403,7 +411,7 @@ class CustomerControllerApi(object):
         auth_settings = ['X-Authorization']  # noqa: E501
 
         return self.api_client.call_api(
-            '/api/customers{?textSearch,idOffset,textOffset,limit}', 'GET',
+            '/api/customers{?textSearch,sortProperty,sortOrder,pageSize,page}', 'GET',
             path_params,
             query_params,
             header_params,

--- a/tb_rest_client/api/api_ce/dashboard_controller_api.py
+++ b/tb_rest_client/api/api_ce/dashboard_controller_api.py
@@ -422,53 +422,53 @@ class DashboardControllerApi(object):
             _request_timeout=params.get('_request_timeout'),
             collection_formats=collection_formats)
 
-    def get_customer_dashboards_using_get(self, customer_id, limit, **kwargs):  # noqa: E501
+    def get_customer_dashboards_using_get(self, customer_id, page_size, page, **kwargs):  # noqa: E501
         """getCustomerDashboards  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
-        >>> thread = api_pe.get_customer_dashboards_using_get(customer_id, limit, async_req=True)
+        >>> thread = api_pe.get_customer_dashboards_using_get(customer_id, page_size, page, async_req=True)
         >>> result = thread.get()
 
         :param async_req bool
         :param str customer_id: customerId (required)
-        :param str limit: limit (required)
-        :param int start_time: startTime
-        :param int end_time: endTime
-        :param bool asc_order: ascOrder
-        :param str offset: offset
+        :param str text_search: textSearch
+        :param str sort_property: sortProperty
+        :param str sort_order: sortOrder
+        :param str page_size: pageSize (required)
+        :param str page: page (required)
         :return: TimePageDataDashboardInfo
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
-            return self.get_customer_dashboards_using_get_with_http_info(customer_id, limit, **kwargs)  # noqa: E501
+            return self.get_customer_dashboards_using_get_with_http_info(customer_id, page_size, page, **kwargs)  # noqa: E501
         else:
-            (data) = self.get_customer_dashboards_using_get_with_http_info(customer_id, limit, **kwargs)  # noqa: E501
+            (data) = self.get_customer_dashboards_using_get_with_http_info(customer_id, page_size, page, **kwargs)  # noqa: E501
             return data
 
-    def get_customer_dashboards_using_get_with_http_info(self, customer_id, limit, **kwargs):  # noqa: E501
+    def get_customer_dashboards_using_get_with_http_info(self, customer_id, page_size, page, **kwargs):  # noqa: E501
         """getCustomerDashboards  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
-        >>> thread = api_pe.get_customer_dashboards_using_get_with_http_info(customer_id, limit, async_req=True)
+        >>> thread = api_pe.get_customer_dashboards_using_get_with_http_info(customer_id, page_size, page, async_req=True)
         >>> result = thread.get()
 
         :param async_req bool
         :param str customer_id: customerId (required)
-        :param str limit: limit (required)
-        :param int start_time: startTime
-        :param int end_time: endTime
-        :param bool asc_order: ascOrder
-        :param str offset: offset
+        :param str text_search: textSearch
+        :param str sort_property: sortProperty
+        :param str sort_order: sortOrder
+        :param str page_size: pageSize (required)
+        :param str page: page (required)
         :return: TimePageDataDashboardInfo
                  If the method is called asynchronously,
                  returns the request thread.
         """
 
-        all_params = ['customer_id', 'limit', 'start_time', 'end_time', 'asc_order', 'offset']  # noqa: E501
+        all_params = ['customer_id', 'text_search', 'sort_property', 'sort_order', 'page_size', 'page']  # noqa: E501
         all_params.append('async_req')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
@@ -483,10 +483,14 @@ class DashboardControllerApi(object):
         if ('customer_id' not in params or
                 params['customer_id'] is None):
             raise ValueError("Missing the required parameter `customer_id` when calling `get_customer_dashboards_using_get`")  # noqa: E501
-        # verify the required parameter 'limit' is set
-        if ('limit' not in params or
-                params['limit'] is None):
-            raise ValueError("Missing the required parameter `limit` when calling `get_customer_dashboards_using_get`")  # noqa: E501
+        # verify the required parameter 'page_size' is set
+        if ('page_size' not in params or
+                params['page_size'] is None):
+            raise ValueError("Missing the required parameter `page_size` when calling `get_customer_dashboards_using_get`")  # noqa: E501
+        # verify the required parameter 'page' is set
+        if ('page' not in params or
+                params['page'] is None):
+            raise ValueError("Missing the required parameter `page` when calling `get_customer_dashboards_using_get`")  # noqa: E501
 
         collection_formats = {}
 
@@ -495,16 +499,16 @@ class DashboardControllerApi(object):
             path_params['customerId'] = params['customer_id']  # noqa: E501
 
         query_params = []
-        if 'start_time' in params:
-            query_params.append(('startTime', params['start_time']))  # noqa: E501
-        if 'end_time' in params:
-            query_params.append(('endTime', params['end_time']))  # noqa: E501
-        if 'asc_order' in params:
-            query_params.append(('ascOrder', params['asc_order']))  # noqa: E501
-        if 'offset' in params:
-            query_params.append(('offset', params['offset']))  # noqa: E501
-        if 'limit' in params:
-            query_params.append(('limit', params['limit']))  # noqa: E501
+        if 'text_search' in params:
+            query_params.append(('textSearch', params['text_search']))  # noqa: E501
+        if 'sort_property' in params:
+            query_params.append(('sortProperty', params['sort_property']))  # noqa: E501
+        if 'sort_order' in params:
+            query_params.append(('sortOrder', params['sort_order']))  # noqa: E501
+        if 'page_size' in params:
+            query_params.append(('pageSize', params['page_size']))  # noqa: E501
+        if 'page' in params:
+            query_params.append(('page', params['page']))  # noqa: E501
 
         header_params = {}
 
@@ -524,7 +528,7 @@ class DashboardControllerApi(object):
         auth_settings = ['X-Authorization']  # noqa: E501
 
         return self.api_client.call_api(
-            '/api/customer/{customerId}/dashboards{?startTime,endTime,ascOrder,offset,limit}', 'GET',
+            '/api/customer/{customerId}/dashboards{?textSearch,sortProperty,sortOrder,pageSize,page}', 'GET',
             path_params,
             query_params,
             header_params,
@@ -895,49 +899,51 @@ class DashboardControllerApi(object):
             _request_timeout=params.get('_request_timeout'),
             collection_formats=collection_formats)
 
-    def get_tenant_dashboards_using_get(self, limit, **kwargs):  # noqa: E501
+    def get_tenant_dashboards_using_get(self, page_size, page, **kwargs):  # noqa: E501
         """getTenantDashboards  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
-        >>> thread = api_pe.get_tenant_dashboards_using_get(limit, async_req=True)
+        >>> thread = api_pe.get_tenant_dashboards_using_get(page_size, page, async_req=True)
         >>> result = thread.get()
 
         :param async_req bool
-        :param str limit: limit (required)
         :param str text_search: textSearch
-        :param str id_offset: idOffset
-        :param str text_offset: textOffset
+        :param str sort_property: sortProperty
+        :param str sort_order: sortOrder
+        :param str page_size: pageSize (required)
+        :param str page: page (required)
         :return: TextPageDataDashboardInfo
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
-            return self.get_tenant_dashboards_using_get_with_http_info(limit, **kwargs)  # noqa: E501
+            return self.get_tenant_dashboards_using_get_with_http_info(page_size, page, **kwargs)  # noqa: E501
         else:
-            (data) = self.get_tenant_dashboards_using_get_with_http_info(limit, **kwargs)  # noqa: E501
+            (data) = self.get_tenant_dashboards_using_get_with_http_info(page_size, page, **kwargs)  # noqa: E501
             return data
 
-    def get_tenant_dashboards_using_get_with_http_info(self, limit, **kwargs):  # noqa: E501
+    def get_tenant_dashboards_using_get_with_http_info(self, page_size, page, **kwargs):  # noqa: E501
         """getTenantDashboards  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
-        >>> thread = api_pe.get_tenant_dashboards_using_get_with_http_info(limit, async_req=True)
+        >>> thread = api_pe.get_tenant_dashboards_using_get_with_http_info(page_size, page, async_req=True)
         >>> result = thread.get()
 
         :param async_req bool
-        :param str limit: limit (required)
         :param str text_search: textSearch
-        :param str id_offset: idOffset
-        :param str text_offset: textOffset
+        :param str sort_property: sortProperty
+        :param str sort_order: sortOrder
+        :param str page_size: pageSize (required)
+        :param str page: page (required)
         :return: TextPageDataDashboardInfo
                  If the method is called asynchronously,
                  returns the request thread.
         """
 
-        all_params = ['limit', 'text_search', 'id_offset', 'text_offset']  # noqa: E501
+        all_params = ['text_search', 'sort_property', 'sort_order', 'page_size', 'page']  # noqa: E501
         all_params.append('async_req')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
@@ -948,10 +954,14 @@ class DashboardControllerApi(object):
             
             params[key] = val
         del params['kwargs']
-        # verify the required parameter 'limit' is set
-        if ('limit' not in params or
-                params['limit'] is None):
-            raise ValueError("Missing the required parameter `limit` when calling `get_tenant_dashboards_using_get`")  # noqa: E501
+        # verify the required parameter 'page_size' is set
+        if ('page_size' not in params or
+                params['page_size'] is None):
+            raise ValueError("Missing the required parameter `page_size` when calling `get_tenant_dashboards_using_get`")  # noqa: E501
+        # verify the required parameter 'page' is set
+        if ('page' not in params or
+                params['page'] is None):
+            raise ValueError("Missing the required parameter `page` when calling `get_tenant_dashboards_using_get`")  # noqa: E501
 
         collection_formats = {}
 
@@ -960,12 +970,14 @@ class DashboardControllerApi(object):
         query_params = []
         if 'text_search' in params:
             query_params.append(('textSearch', params['text_search']))  # noqa: E501
-        if 'id_offset' in params:
-            query_params.append(('idOffset', params['id_offset']))  # noqa: E501
-        if 'text_offset' in params:
-            query_params.append(('textOffset', params['text_offset']))  # noqa: E501
-        if 'limit' in params:
-            query_params.append(('limit', params['limit']))  # noqa: E501
+        if 'sort_property' in params:
+            query_params.append(('sortProperty', params['sort_property']))  # noqa: E501
+        if 'sort_order' in params:
+            query_params.append(('sortOrder', params['sort_order']))  # noqa: E501
+        if 'page_size' in params:
+            query_params.append(('pageSize', params['page_size']))  # noqa: E501
+        if 'page' in params:
+            query_params.append(('page', params['page']))  # noqa: E501
 
         header_params = {}
 
@@ -985,7 +997,7 @@ class DashboardControllerApi(object):
         auth_settings = ['X-Authorization']  # noqa: E501
 
         return self.api_client.call_api(
-            '/api/tenant/dashboards{?textSearch,idOffset,textOffset,limit}', 'GET',
+            '/api/tenant/dashboards{?textSearch,sortProperty,sortOrder,pageSize,page}', 'GET',
             path_params,
             query_params,
             header_params,
@@ -1000,51 +1012,53 @@ class DashboardControllerApi(object):
             _request_timeout=params.get('_request_timeout'),
             collection_formats=collection_formats)
 
-    def get_tenant_dashboards_using_get1(self, tenant_id, limit, **kwargs):  # noqa: E501
+    def get_tenant_dashboards_using_get1(self, tenant_id, page_size, page, **kwargs):  # noqa: E501
         """getTenantDashboards  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
-        >>> thread = api_pe.get_tenant_dashboards_using_get1(tenant_id, limit, async_req=True)
+        >>> thread = api_pe.get_tenant_dashboards_using_get1(tenant_id, page_size, page, async_req=True)
         >>> result = thread.get()
 
         :param async_req bool
         :param str tenant_id: tenantId (required)
-        :param str limit: limit (required)
         :param str text_search: textSearch
-        :param str id_offset: idOffset
-        :param str text_offset: textOffset
+        :param str sort_property: sortProperty
+        :param str sort_order: sortOrder
+        :param str page_size: pageSize (required)
+        :param str page: page (required)
         :return: TextPageDataDashboardInfo
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
-            return self.get_tenant_dashboards_using_get1_with_http_info(tenant_id, limit, **kwargs)  # noqa: E501
+            return self.get_tenant_dashboards_using_get1_with_http_info(tenant_id, page_size, page, **kwargs)  # noqa: E501
         else:
-            (data) = self.get_tenant_dashboards_using_get1_with_http_info(tenant_id, limit, **kwargs)  # noqa: E501
+            (data) = self.get_tenant_dashboards_using_get1_with_http_info(tenant_id, page_size, page, **kwargs)  # noqa: E501
             return data
 
-    def get_tenant_dashboards_using_get1_with_http_info(self, tenant_id, limit, **kwargs):  # noqa: E501
+    def get_tenant_dashboards_using_get1_with_http_info(self, tenant_id, page_size, page, **kwargs):  # noqa: E501
         """getTenantDashboards  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
-        >>> thread = api_pe.get_tenant_dashboards_using_get1_with_http_info(tenant_id, limit, async_req=True)
+        >>> thread = api_pe.get_tenant_dashboards_using_get1_with_http_info(tenant_id, page_size, page, async_req=True)
         >>> result = thread.get()
 
         :param async_req bool
         :param str tenant_id: tenantId (required)
-        :param str limit: limit (required)
         :param str text_search: textSearch
-        :param str id_offset: idOffset
-        :param str text_offset: textOffset
+        :param str sort_property: sortProperty
+        :param str sort_order: sortOrder
+        :param str page_size: pageSize (required)
+        :param str page: page (required)
         :return: TextPageDataDashboardInfo
                  If the method is called asynchronously,
                  returns the request thread.
         """
 
-        all_params = ['tenant_id', 'limit', 'text_search', 'id_offset', 'text_offset']  # noqa: E501
+        all_params = ['tenant_id', 'text_search', 'sort_property', 'sort_order', 'page_size', 'page']  # noqa: E501
         all_params.append('async_req')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
@@ -1059,10 +1073,14 @@ class DashboardControllerApi(object):
         if ('tenant_id' not in params or
                 params['tenant_id'] is None):
             raise ValueError("Missing the required parameter `tenant_id` when calling `get_tenant_dashboards_using_get1`")  # noqa: E501
-        # verify the required parameter 'limit' is set
-        if ('limit' not in params or
-                params['limit'] is None):
-            raise ValueError("Missing the required parameter `limit` when calling `get_tenant_dashboards_using_get1`")  # noqa: E501
+        # verify the required parameter 'page_size' is set
+        if ('page_size' not in params or
+                params['page_size'] is None):
+            raise ValueError("Missing the required parameter `page_size` when calling `get_tenant_dashboards_using_get1`")  # noqa: E501
+        # verify the required parameter 'page' is set
+        if ('page' not in params or
+                params['page'] is None):
+            raise ValueError("Missing the required parameter `page` when calling `get_tenant_dashboards_using_get1`")  # noqa: E501
 
         collection_formats = {}
 
@@ -1073,12 +1091,14 @@ class DashboardControllerApi(object):
         query_params = []
         if 'text_search' in params:
             query_params.append(('textSearch', params['text_search']))  # noqa: E501
-        if 'id_offset' in params:
-            query_params.append(('idOffset', params['id_offset']))  # noqa: E501
-        if 'text_offset' in params:
-            query_params.append(('textOffset', params['text_offset']))  # noqa: E501
-        if 'limit' in params:
-            query_params.append(('limit', params['limit']))  # noqa: E501
+        if 'sort_property' in params:
+            query_params.append(('sortProperty', params['sort_property']))  # noqa: E501
+        if 'sort_order' in params:
+            query_params.append(('sortOrder', params['sort_order']))  # noqa: E501
+        if 'page_size' in params:
+            query_params.append(('pageSize', params['page_size']))  # noqa: E501
+        if 'page' in params:
+            query_params.append(('page', params['page']))  # noqa: E501
 
         header_params = {}
 
@@ -1098,7 +1118,7 @@ class DashboardControllerApi(object):
         auth_settings = ['X-Authorization']  # noqa: E501
 
         return self.api_client.call_api(
-            '/api/tenant/{tenantId}/dashboards{?textSearch,idOffset,textOffset,limit}', 'GET',
+            '/api/tenant/{tenantId}/dashboards{?textSearch,sortProperty,sortOrder,pageSize,page}', 'GET',
             path_params,
             query_params,
             header_params,

--- a/tb_rest_client/api/api_ce/device_controller_api.py
+++ b/tb_rest_client/api/api_ce/device_controller_api.py
@@ -511,53 +511,55 @@ class DeviceControllerApi(object):
             _request_timeout=params.get('_request_timeout'),
             collection_formats=collection_formats)
 
-    def get_customer_devices_using_get(self, customer_id, limit, **kwargs):  # noqa: E501
+    def get_customer_devices_using_get(self, customer_id, page_size, page, **kwargs):  # noqa: E501
         """getCustomerDevices  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
-        >>> thread = api_pe.get_customer_devices_using_get(customer_id, limit, async_req=True)
+        >>> thread = api_pe.get_customer_devices_using_get(customer_id, page_size, page, async_req=True)
         >>> result = thread.get()
 
         :param async_req bool
         :param str customer_id: customerId (required)
-        :param str limit: limit (required)
         :param str type: type
         :param str text_search: textSearch
-        :param str id_offset: idOffset
-        :param str text_offset: textOffset
+        :param str sort_property: sortProperty
+        :param str sort_order: sortOrder
+        :param str page_size: pageSize (required)
+        :param str page: page (required)
         :return: TextPageDataDevice
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
-            return self.get_customer_devices_using_get_with_http_info(customer_id, limit, **kwargs)  # noqa: E501
+            return self.get_customer_devices_using_get_with_http_info(customer_id, **kwargs)  # noqa: E501
         else:
-            (data) = self.get_customer_devices_using_get_with_http_info(customer_id, limit, **kwargs)  # noqa: E501
+            (data) = self.get_customer_devices_using_get_with_http_info(customer_id, **kwargs)  # noqa: E501
             return data
 
-    def get_customer_devices_using_get_with_http_info(self, customer_id, limit, **kwargs):  # noqa: E501
+    def get_customer_devices_using_get_with_http_info(self, customer_id, page_size, page, **kwargs):  # noqa: E501
         """getCustomerDevices  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
-        >>> thread = api_pe.get_customer_devices_using_get_with_http_info(customer_id, limit, async_req=True)
+        >>> thread = api_pe.get_customer_devices_using_get_with_http_info(customer_id, async_req=True)
         >>> result = thread.get()
 
         :param async_req bool
         :param str customer_id: customerId (required)
-        :param str limit: limit (required)
         :param str type: type
         :param str text_search: textSearch
-        :param str id_offset: idOffset
-        :param str text_offset: textOffset
+        :param str sort_property: sortProperty
+        :param str sort_order: sortOrder
+        :param str page_size: pageSize (required)
+        :param str page: page (required)
         :return: TextPageDataDevice
                  If the method is called asynchronously,
                  returns the request thread.
         """
 
-        all_params = ['customer_id', 'limit', 'type', 'text_search', 'id_offset', 'text_offset']  # noqa: E501
+        all_params = ['customer_id', 'limit', 'type', 'text_search', 'sort_property', 'sort_order', 'page_size', 'page']  # noqa: E501
         all_params.append('async_req')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
@@ -572,10 +574,14 @@ class DeviceControllerApi(object):
         if ('customer_id' not in params or
                 params['customer_id'] is None):
             raise ValueError("Missing the required parameter `customer_id` when calling `get_customer_devices_using_get`")  # noqa: E501
-        # verify the required parameter 'limit' is set
-        if ('limit' not in params or
-                params['limit'] is None):
-            raise ValueError("Missing the required parameter `limit` when calling `get_customer_devices_using_get`")  # noqa: E501
+        # verify the required parameter 'page_size' is set
+        if ('page_size' not in params or
+                params['page_size'] is None):
+            raise ValueError("Missing the required parameter `page_size` when calling `get_customer_devices_using_get`")  # noqa: E501
+        # verify the required parameter 'page' is set
+        if ('page' not in params or
+                params['page'] is None):
+            raise ValueError("Missing the required parameter `page` when calling `get_customer_devices_using_get`")  # noqa: E501
 
         collection_formats = {}
 
@@ -588,12 +594,14 @@ class DeviceControllerApi(object):
             query_params.append(('type', params['type']))  # noqa: E501
         if 'text_search' in params:
             query_params.append(('textSearch', params['text_search']))  # noqa: E501
-        if 'id_offset' in params:
-            query_params.append(('idOffset', params['id_offset']))  # noqa: E501
-        if 'text_offset' in params:
-            query_params.append(('textOffset', params['text_offset']))  # noqa: E501
-        if 'limit' in params:
-            query_params.append(('limit', params['limit']))  # noqa: E501
+        if 'sort_property' in params:
+            query_params.append(('sortProperty', params['sort_property']))  # noqa: E501
+        if 'sort_order' in params:
+            query_params.append(('sortOrder', params['sort_order']))  # noqa: E501
+        if 'page_size' in params:
+            query_params.append(('pageSize', params['page_size']))  # noqa: E501
+        if 'page' in params:
+            query_params.append(('page', params['page']))  # noqa: E501
 
         header_params = {}
 
@@ -613,7 +621,7 @@ class DeviceControllerApi(object):
         auth_settings = ['X-Authorization']  # noqa: E501
 
         return self.api_client.call_api(
-            '/api/customer/{customerId}/devices{?type,textSearch,idOffset,textOffset,limit}', 'GET',
+            '/api/customer/{customerId}/devices{?type,textSearch,sortProperty,sortOrder,pageSize,page}', 'GET',
             path_params,
             query_params,
             header_params,
@@ -1085,51 +1093,53 @@ class DeviceControllerApi(object):
             _request_timeout=params.get('_request_timeout'),
             collection_formats=collection_formats)
 
-    def get_tenant_devices_using_get(self, limit, **kwargs):  # noqa: E501
+    def get_tenant_devices_using_get(self, page_size, page, **kwargs):  # noqa: E501
         """getTenantDevices  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
-        >>> thread = api_pe.get_tenant_devices_using_get(limit, async_req=True)
+        >>> thread = api_pe.get_tenant_devices_using_get(page_size, page, async_req=True)
         >>> result = thread.get()
 
         :param async_req bool
-        :param str limit: limit (required)
         :param str type: type
         :param str text_search: textSearch
-        :param str id_offset: idOffset
-        :param str text_offset: textOffset
+        :param str sort_property: sortProperty
+        :param str sort_order: sortOrder
+        :param str page_size: pageSize (required)
+        :param str page: page (required)
         :return: TextPageDataDevice
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
-            return self.get_tenant_devices_using_get_with_http_info(limit, **kwargs)  # noqa: E501
+            return self.get_tenant_devices_using_get_with_http_info(page_size, page, **kwargs)  # noqa: E501
         else:
-            (data) = self.get_tenant_devices_using_get_with_http_info(limit, **kwargs)  # noqa: E501
+            (data) = self.get_tenant_devices_using_get_with_http_info(page_size, page, **kwargs)  # noqa: E501
             return data
 
-    def get_tenant_devices_using_get_with_http_info(self, limit, **kwargs):  # noqa: E501
+    def get_tenant_devices_using_get_with_http_info(self, page_size, page, **kwargs):  # noqa: E501
         """getTenantDevices  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
-        >>> thread = api_pe.get_tenant_devices_using_get_with_http_info(limit, async_req=True)
+        >>> thread = api_pe.get_tenant_devices_using_get_with_http_info(page_size, page, async_req=True)
         >>> result = thread.get()
 
         :param async_req bool
-        :param str limit: limit (required)
         :param str type: type
         :param str text_search: textSearch
-        :param str id_offset: idOffset
-        :param str text_offset: textOffset
+        :param str sort_property: sortProperty
+        :param str sort_order: sortOrder
+        :param str page_size: pageSize (required)
+        :param str page: page (required)
         :return: TextPageDataDevice
                  If the method is called asynchronously,
                  returns the request thread.
         """
 
-        all_params = ['limit', 'type', 'text_search', 'id_offset', 'text_offset']  # noqa: E501
+        all_params = ['type', 'text_search', 'sort_property', 'sort_order', 'page_size', 'page']  # noqa: E501
         all_params.append('async_req')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
@@ -1140,10 +1150,14 @@ class DeviceControllerApi(object):
             
             params[key] = val
         del params['kwargs']
-        # verify the required parameter 'limit' is set
-        if ('limit' not in params or
-                params['limit'] is None):
-            raise ValueError("Missing the required parameter `limit` when calling `get_tenant_devices_using_get`")  # noqa: E501
+        # verify the required parameter 'page_size' is set
+        if ('page_size' not in params or
+                params['page_size'] is None):
+            raise ValueError("Missing the required parameter `page_size` when calling `get_tenant_devices_using_get`")  # noqa: E501
+        # verify the required parameter 'page' is set
+        if ('page' not in params or
+                params['page'] is None):
+            raise ValueError("Missing the required parameter `page` when calling `get_tenant_devices_using_get`")  # noqa: E501
 
         collection_formats = {}
 
@@ -1154,12 +1168,14 @@ class DeviceControllerApi(object):
             query_params.append(('type', params['type']))  # noqa: E501
         if 'text_search' in params:
             query_params.append(('textSearch', params['text_search']))  # noqa: E501
-        if 'id_offset' in params:
-            query_params.append(('idOffset', params['id_offset']))  # noqa: E501
-        if 'text_offset' in params:
-            query_params.append(('textOffset', params['text_offset']))  # noqa: E501
-        if 'limit' in params:
-            query_params.append(('limit', params['limit']))  # noqa: E501
+        if 'sort_property' in params:
+            query_params.append(('sortProperty', params['sort_property']))  # noqa: E501
+        if 'sort_order' in params:
+            query_params.append(('sortOrder', params['sort_order']))  # noqa: E501
+        if 'page_size' in params:
+            query_params.append(('pageSize', params['page_size']))  # noqa: E501
+        if 'page' in params:
+            query_params.append(('page', params['page']))  # noqa: E501
 
         header_params = {}
 
@@ -1179,7 +1195,7 @@ class DeviceControllerApi(object):
         auth_settings = ['X-Authorization']  # noqa: E501
 
         return self.api_client.call_api(
-            '/api/tenant/devices{?type,textSearch,idOffset,textOffset,limit}', 'GET',
+            '/api/tenant/devices{?type,textSearch,sortProperty,sortOrder,pageSize,page}', 'GET',
             path_params,
             query_params,
             header_params,

--- a/tb_rest_client/api/api_ce/device_controller_api.py
+++ b/tb_rest_client/api/api_ce/device_controller_api.py
@@ -559,7 +559,7 @@ class DeviceControllerApi(object):
                  returns the request thread.
         """
 
-        all_params = ['customer_id', 'limit', 'type', 'text_search', 'sort_property', 'sort_order', 'page_size', 'page']  # noqa: E501
+        all_params = ['customer_id', 'type', 'text_search', 'sort_property', 'sort_order', 'page_size', 'page']  # noqa: E501
         all_params.append('async_req')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')

--- a/tb_rest_client/api/api_ce/device_controller_api.py
+++ b/tb_rest_client/api/api_ce/device_controller_api.py
@@ -533,9 +533,9 @@ class DeviceControllerApi(object):
         """
         kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
-            return self.get_customer_devices_using_get_with_http_info(customer_id, **kwargs)  # noqa: E501
+            return self.get_customer_devices_using_get_with_http_info(customer_id, page_size, page, **kwargs)  # noqa: E501
         else:
-            (data) = self.get_customer_devices_using_get_with_http_info(customer_id, **kwargs)  # noqa: E501
+            (data) = self.get_customer_devices_using_get_with_http_info(customer_id, page_size, page, **kwargs)  # noqa: E501
             return data
 
     def get_customer_devices_using_get_with_http_info(self, customer_id, page_size, page, **kwargs):  # noqa: E501

--- a/tb_rest_client/api/api_ce/entity_view_controller_api.py
+++ b/tb_rest_client/api/api_ce/entity_view_controller_api.py
@@ -414,53 +414,55 @@ class EntityViewControllerApi(object):
             _request_timeout=params.get('_request_timeout'),
             collection_formats=collection_formats)
 
-    def get_customer_entity_views_using_get(self, customer_id, limit, **kwargs):  # noqa: E501
+    def get_customer_entity_views_using_get(self, customer_id, page_size, page, **kwargs):  # noqa: E501
         """getCustomerEntityViews  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
-        >>> thread = api_pe.get_customer_entity_views_using_get(customer_id, limit, async_req=True)
+        >>> thread = api_pe.get_customer_entity_views_using_get(customer_id, page_size, page, async_req=True)
         >>> result = thread.get()
 
         :param async_req bool
         :param str customer_id: customerId (required)
-        :param str limit: limit (required)
         :param str type: type
         :param str text_search: textSearch
-        :param str id_offset: idOffset
-        :param str text_offset: textOffset
+        :param str sort_property: sortProperty
+        :param str sort_order: sortOrder
+        :param str page_size: pageSize (required)
+        :param str page: page (required)
         :return: TextPageDataEntityView
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
-            return self.get_customer_entity_views_using_get_with_http_info(customer_id, limit, **kwargs)  # noqa: E501
+            return self.get_customer_entity_views_using_get_with_http_info(customer_id, page_size, page, **kwargs)  # noqa: E501
         else:
-            (data) = self.get_customer_entity_views_using_get_with_http_info(customer_id, limit, **kwargs)  # noqa: E501
+            (data) = self.get_customer_entity_views_using_get_with_http_info(customer_id, page_size, page, **kwargs)  # noqa: E501
             return data
 
-    def get_customer_entity_views_using_get_with_http_info(self, customer_id, limit, **kwargs):  # noqa: E501
+    def get_customer_entity_views_using_get_with_http_info(self, customer_id, page_size, page, **kwargs):  # noqa: E501
         """getCustomerEntityViews  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
-        >>> thread = api_pe.get_customer_entity_views_using_get_with_http_info(customer_id, limit, async_req=True)
+        >>> thread = api_pe.get_customer_entity_views_using_get_with_http_info(customer_id, page_size, page, async_req=True)
         >>> result = thread.get()
 
         :param async_req bool
         :param str customer_id: customerId (required)
-        :param str limit: limit (required)
         :param str type: type
         :param str text_search: textSearch
-        :param str id_offset: idOffset
-        :param str text_offset: textOffset
+        :param str sort_property: sortProperty
+        :param str sort_order: sortOrder
+        :param str page_size: pageSize (required)
+        :param str page: page (required)
         :return: TextPageDataEntityView
                  If the method is called asynchronously,
                  returns the request thread.
         """
 
-        all_params = ['customer_id', 'limit', 'type', 'text_search', 'id_offset', 'text_offset']  # noqa: E501
+        all_params = ['customer_id', 'type', 'text_search', 'sort_property', 'sort_order', 'page_size', 'page']  # noqa: E501
         all_params.append('async_req')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
@@ -475,10 +477,14 @@ class EntityViewControllerApi(object):
         if ('customer_id' not in params or
                 params['customer_id'] is None):
             raise ValueError("Missing the required parameter `customer_id` when calling `get_customer_entity_views_using_get`")  # noqa: E501
-        # verify the required parameter 'limit' is set
-        if ('limit' not in params or
-                params['limit'] is None):
-            raise ValueError("Missing the required parameter `limit` when calling `get_customer_entity_views_using_get`")  # noqa: E501
+        # verify the required parameter 'page_size' is set
+        if ('page_size' not in params or
+                params['page_size'] is None):
+            raise ValueError("Missing the required parameter `page_size` when calling `get_customer_entity_views_using_get`")  # noqa: E501
+        # verify the required parameter 'page' is set
+        if ('page' not in params or
+                params['page'] is None):
+            raise ValueError("Missing the required parameter `page` when calling `get_customer_entity_views_using_get`")  # noqa: E501
 
         collection_formats = {}
 
@@ -491,12 +497,14 @@ class EntityViewControllerApi(object):
             query_params.append(('type', params['type']))  # noqa: E501
         if 'text_search' in params:
             query_params.append(('textSearch', params['text_search']))  # noqa: E501
-        if 'id_offset' in params:
-            query_params.append(('idOffset', params['id_offset']))  # noqa: E501
-        if 'text_offset' in params:
-            query_params.append(('textOffset', params['text_offset']))  # noqa: E501
-        if 'limit' in params:
-            query_params.append(('limit', params['limit']))  # noqa: E501
+        if 'sort_property' in params:
+            query_params.append(('sortProperty', params['sort_property']))  # noqa: E501
+        if 'sort_order' in params:
+            query_params.append(('sortOrder', params['sort_order']))  # noqa: E501
+        if 'page_size' in params:
+            query_params.append(('pageSize', params['page_size']))  # noqa: E501
+        if 'page' in params:
+            query_params.append(('page', params['page']))  # noqa: E501
 
         header_params = {}
 
@@ -516,7 +524,7 @@ class EntityViewControllerApi(object):
         auth_settings = ['X-Authorization']  # noqa: E501
 
         return self.api_client.call_api(
-            '/api/customer/{customerId}/entityViews{?type,textSearch,idOffset,textOffset,limit}', 'GET',
+            '/api/customer/{customerId}/entityViews{?type,textSearch,sortProperty,sortOrder,pageSize,page}', 'GET',
             path_params,
             query_params,
             header_params,
@@ -802,51 +810,53 @@ class EntityViewControllerApi(object):
             _request_timeout=params.get('_request_timeout'),
             collection_formats=collection_formats)
 
-    def get_tenant_entity_views_using_get(self, limit, **kwargs):  # noqa: E501
+    def get_tenant_entity_views_using_get(self, page_size, page, **kwargs):  # noqa: E501
         """getTenantEntityViews  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
-        >>> thread = api_pe.get_tenant_entity_views_using_get(limit, async_req=True)
+        >>> thread = api_pe.get_tenant_entity_views_using_get(page_size, page, async_req=True)
         >>> result = thread.get()
 
         :param async_req bool
-        :param str limit: limit (required)
         :param str type: type
         :param str text_search: textSearch
-        :param str id_offset: idOffset
-        :param str text_offset: textOffset
+        :param str sort_property: sortProperty
+        :param str sort_order: sortOrder
+        :param str page_size: pageSize (required)
+        :param str page: page (required)
         :return: TextPageDataEntityView
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
-            return self.get_tenant_entity_views_using_get_with_http_info(limit, **kwargs)  # noqa: E501
+            return self.get_tenant_entity_views_using_get_with_http_info(page_size, page, **kwargs)  # noqa: E501
         else:
-            (data) = self.get_tenant_entity_views_using_get_with_http_info(limit, **kwargs)  # noqa: E501
+            (data) = self.get_tenant_entity_views_using_get_with_http_info(page_size, page, **kwargs)  # noqa: E501
             return data
 
-    def get_tenant_entity_views_using_get_with_http_info(self, limit, **kwargs):  # noqa: E501
+    def get_tenant_entity_views_using_get_with_http_info(self, page_size, page, **kwargs):  # noqa: E501
         """getTenantEntityViews  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
-        >>> thread = api_pe.get_tenant_entity_views_using_get_with_http_info(limit, async_req=True)
+        >>> thread = api_pe.get_tenant_entity_views_using_get_with_http_info(page_size, page, async_req=True)
         >>> result = thread.get()
 
         :param async_req bool
-        :param str limit: limit (required)
         :param str type: type
         :param str text_search: textSearch
-        :param str id_offset: idOffset
-        :param str text_offset: textOffset
+        :param str sort_property: sortProperty
+        :param str sort_order: sortOrder
+        :param str page_size: pageSize (required)
+        :param str page: page (required)
         :return: TextPageDataEntityView
                  If the method is called asynchronously,
                  returns the request thread.
         """
 
-        all_params = ['limit', 'type', 'text_search', 'id_offset', 'text_offset']  # noqa: E501
+        all_params = ['type', 'text_search', 'sort_property', 'sort_order', 'page_size', 'page']  # noqa: E501
         all_params.append('async_req')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
@@ -857,10 +867,14 @@ class EntityViewControllerApi(object):
             
             params[key] = val
         del params['kwargs']
-        # verify the required parameter 'limit' is set
-        if ('limit' not in params or
-                params['limit'] is None):
-            raise ValueError("Missing the required parameter `limit` when calling `get_tenant_entity_views_using_get`")  # noqa: E501
+        # verify the required parameter 'page_size' is set
+        if ('page_size' not in params or
+                params['page_size'] is None):
+            raise ValueError("Missing the required parameter `page_size` when calling `get_tenant_entity_views_using_get`")  # noqa: E501
+        # verify the required parameter 'page' is set
+        if ('page' not in params or
+                params['page'] is None):
+            raise ValueError("Missing the required parameter `page` when calling `get_tenant_entity_views_using_get`")  # noqa: E501
 
         collection_formats = {}
 
@@ -871,12 +885,14 @@ class EntityViewControllerApi(object):
             query_params.append(('type', params['type']))  # noqa: E501
         if 'text_search' in params:
             query_params.append(('textSearch', params['text_search']))  # noqa: E501
-        if 'id_offset' in params:
-            query_params.append(('idOffset', params['id_offset']))  # noqa: E501
-        if 'text_offset' in params:
-            query_params.append(('textOffset', params['text_offset']))  # noqa: E501
-        if 'limit' in params:
-            query_params.append(('limit', params['limit']))  # noqa: E501
+        if 'sort_property' in params:
+            query_params.append(('sortProperty', params['sort_property']))  # noqa: E501
+        if 'sort_order' in params:
+            query_params.append(('sortOrder', params['sort_order']))  # noqa: E501
+        if 'page_size' in params:
+            query_params.append(('pageSize', params['page_size']))  # noqa: E501
+        if 'page' in params:
+            query_params.append(('page', params['page']))  # noqa: E501
 
         header_params = {}
 
@@ -896,7 +912,7 @@ class EntityViewControllerApi(object):
         auth_settings = ['X-Authorization']  # noqa: E501
 
         return self.api_client.call_api(
-            '/api/tenant/entityViews{?type,textSearch,idOffset,textOffset,limit}', 'GET',
+            '/api/tenant/entityViews{?type,textSearch,sortProperty,sortOrder,pageSize,page}', 'GET',
             path_params,
             query_params,
             header_params,

--- a/tb_rest_client/api/api_ce/event_controller_api.py
+++ b/tb_rest_client/api/api_ce/event_controller_api.py
@@ -34,12 +34,12 @@ class EventControllerApi(object):
             api_client = ApiClient()
         self.api_client = api_client
 
-    def get_events_using_get(self, entity_type, entity_id, event_type, tenant_id, limit, **kwargs):  # noqa: E501
+    def get_events_using_get(self, entity_type, entity_id, event_type, tenant_id, page_size, page, **kwargs):  # noqa: E501
         """getEvents  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
-        >>> thread = api_pe.get_events_using_get(entity_type, entity_id, event_type, tenant_id, limit, async_req=True)
+        >>> thread = api_pe.get_events_using_get(entity_type, entity_id, event_type, tenant_id, page_size, page, async_req=True)
         >>> result = thread.get()
 
         :param async_req bool
@@ -47,28 +47,30 @@ class EventControllerApi(object):
         :param str entity_id: entityId (required)
         :param str event_type: eventType (required)
         :param str tenant_id: tenantId (required)
-        :param int limit: limit (required)
+        :param str page_size: pageSize (required)
+        :param str page: page (required)
+        :param str text_search: textSearch
+        :param str sort_property: sortProperty
+        :param str sort_order: sortOrder
         :param int start_time: startTime
         :param int end_time: endTime
-        :param bool asc_order: ascOrder
-        :param str offset: offset
         :return: TimePageDataEvent
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
-            return self.get_events_using_get_with_http_info(entity_type, entity_id, event_type, tenant_id, limit, **kwargs)  # noqa: E501
+            return self.get_events_using_get_with_http_info(entity_type, entity_id, event_type, tenant_id, page_size, page, **kwargs)  # noqa: E501
         else:
-            (data) = self.get_events_using_get_with_http_info(entity_type, entity_id, event_type, tenant_id, limit, **kwargs)  # noqa: E501
+            (data) = self.get_events_using_get_with_http_info(entity_type, entity_id, event_type, tenant_id, page_size, page, **kwargs)  # noqa: E501
             return data
 
-    def get_events_using_get_with_http_info(self, entity_type, entity_id, event_type, tenant_id, limit, **kwargs):  # noqa: E501
+    def get_events_using_get_with_http_info(self, entity_type, entity_id, event_type, tenant_id, page_size, page, **kwargs):  # noqa: E501
         """getEvents  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
-        >>> thread = api_pe.get_events_using_get_with_http_info(entity_type, entity_id, event_type, tenant_id, limit, async_req=True)
+        >>> thread = api_pe.get_events_using_get_with_http_info(entity_type, entity_id, event_type, tenant_id, page_size, page, async_req=True)
         >>> result = thread.get()
 
         :param async_req bool
@@ -76,17 +78,19 @@ class EventControllerApi(object):
         :param str entity_id: entityId (required)
         :param str event_type: eventType (required)
         :param str tenant_id: tenantId (required)
-        :param int limit: limit (required)
+        :param str page_size: pageSize (required)
+        :param str page: page (required)
+        :param str text_search: textSearch
+        :param str sort_property: sortProperty
+        :param str sort_order: sortOrder
         :param int start_time: startTime
         :param int end_time: endTime
-        :param bool asc_order: ascOrder
-        :param str offset: offset
         :return: TimePageDataEvent
                  If the method is called asynchronously,
                  returns the request thread.
         """
 
-        all_params = ['entity_type', 'entity_id', 'event_type', 'tenant_id', 'limit', 'start_time', 'end_time', 'asc_order', 'offset']  # noqa: E501
+        all_params = ['entity_type', 'entity_id', 'event_type', 'tenant_id', 'page_size', 'page', 'text_search', 'sort_property', 'sort_order', 'start_time', 'end_time']  # noqa: E501
         all_params.append('async_req')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
@@ -113,10 +117,14 @@ class EventControllerApi(object):
         if ('tenant_id' not in params or
                 params['tenant_id'] is None):
             raise ValueError("Missing the required parameter `tenant_id` when calling `get_events_using_get`")  # noqa: E501
-        # verify the required parameter 'limit' is set
-        if ('limit' not in params or
-                params['limit'] is None):
-            raise ValueError("Missing the required parameter `limit` when calling `get_events_using_get`")  # noqa: E501
+        # verify the required parameter 'page_size' is set
+        if ('page_size' not in params or
+                params['page_size'] is None):
+            raise ValueError("Missing the required parameter `page_size` when calling `get_events_using_get`")  # noqa: E501
+        # verify the required parameter 'page' is set
+        if ('page' not in params or
+                params['page'] is None):
+            raise ValueError("Missing the required parameter `page` when calling `get_events_using_get`")  # noqa: E501
 
         collection_formats = {}
 
@@ -131,16 +139,20 @@ class EventControllerApi(object):
         query_params = []
         if 'tenant_id' in params:
             query_params.append(('tenantId', params['tenant_id']))  # noqa: E501
-        if 'limit' in params:
-            query_params.append(('limit', params['limit']))  # noqa: E501
+        if 'page_size' in params:
+            query_params.append(('pageSize', params['page_size']))  # noqa: E501
+        if 'page' in params:
+            query_params.append(('page', params['page']))  # noqa: E501
+        if 'text_search' in params:
+            query_params.append(('textSearch', params['text_search']))  # noqa: E501
+        if 'sort_property' in params:
+            query_params.append(('sortProperty', params['sort_property']))  # noqa: E501
+        if 'sort_order' in params:
+            query_params.append(('sortOrder', params['sort_order']))  # noqa: E501
         if 'start_time' in params:
             query_params.append(('startTime', params['start_time']))  # noqa: E501
         if 'end_time' in params:
             query_params.append(('endTime', params['end_time']))  # noqa: E501
-        if 'asc_order' in params:
-            query_params.append(('ascOrder', params['asc_order']))  # noqa: E501
-        if 'offset' in params:
-            query_params.append(('offset', params['offset']))  # noqa: E501
 
         header_params = {}
 
@@ -160,7 +172,7 @@ class EventControllerApi(object):
         auth_settings = ['X-Authorization']  # noqa: E501
 
         return self.api_client.call_api(
-            '/api/events/{entityType}/{entityId}/{eventType}{?tenantId,limit,startTime,endTime,ascOrder,offset}', 'GET',
+            '/api/events/{entityType}/{entityId}/{eventType}{?tenantId,pageSize,page,textSearch,sortProperty,sortOrder,startTime,endTime}', 'GET',
             path_params,
             query_params,
             header_params,
@@ -175,57 +187,61 @@ class EventControllerApi(object):
             _request_timeout=params.get('_request_timeout'),
             collection_formats=collection_formats)
 
-    def get_events_using_get1(self, entity_type, entity_id, tenant_id, limit, **kwargs):  # noqa: E501
+    def get_events_using_get1(self, entity_type, entity_id, tenant_id, page_size, page, **kwargs):  # noqa: E501
         """getEvents  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
-        >>> thread = api_pe.get_events_using_get1(entity_type, entity_id, tenant_id, limit, async_req=True)
+        >>> thread = api_pe.get_events_using_get1(entity_type, entity_id, tenant_id, page_size, page, async_req=True)
         >>> result = thread.get()
 
         :param async_req bool
         :param str entity_type: entityType (required)
         :param str entity_id: entityId (required)
         :param str tenant_id: tenantId (required)
-        :param int limit: limit (required)
+        :param str page_size: pageSize (required)
+        :param str page: page (required)
+        :param str text_search: textSearch
+        :param str sort_property: sortProperty
+        :param str sort_order: sortOrder
         :param int start_time: startTime
         :param int end_time: endTime
-        :param bool asc_order: ascOrder
-        :param str offset: offset
         :return: TimePageDataEvent
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
-            return self.get_events_using_get1_with_http_info(entity_type, entity_id, tenant_id, limit, **kwargs)  # noqa: E501
+            return self.get_events_using_get1_with_http_info(entity_type, entity_id, tenant_id, page_size, page, **kwargs)  # noqa: E501
         else:
-            (data) = self.get_events_using_get1_with_http_info(entity_type, entity_id, tenant_id, limit, **kwargs)  # noqa: E501
+            (data) = self.get_events_using_get1_with_http_info(entity_type, entity_id, tenant_id, page_size, page, **kwargs)  # noqa: E501
             return data
 
-    def get_events_using_get1_with_http_info(self, entity_type, entity_id, tenant_id, limit, **kwargs):  # noqa: E501
+    def get_events_using_get1_with_http_info(self, entity_type, entity_id, tenant_id, page_size, page, **kwargs):  # noqa: E501
         """getEvents  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
-        >>> thread = api_pe.get_events_using_get1_with_http_info(entity_type, entity_id, tenant_id, limit, async_req=True)
+        >>> thread = api_pe.get_events_using_get1_with_http_info(entity_type, entity_id, tenant_id, page_size, page, async_req=True)
         >>> result = thread.get()
 
         :param async_req bool
         :param str entity_type: entityType (required)
         :param str entity_id: entityId (required)
         :param str tenant_id: tenantId (required)
-        :param int limit: limit (required)
+        :param str page_size: pageSize (required)
+        :param str page: page (required)
+        :param str text_search: textSearch
+        :param str sort_property: sortProperty
+        :param str sort_order: sortOrder
         :param int start_time: startTime
         :param int end_time: endTime
-        :param bool asc_order: ascOrder
-        :param str offset: offset
         :return: TimePageDataEvent
                  If the method is called asynchronously,
                  returns the request thread.
         """
 
-        all_params = ['entity_type', 'entity_id', 'tenant_id', 'limit', 'start_time', 'end_time', 'asc_order', 'offset']  # noqa: E501
+        all_params = ['entity_type', 'entity_id', 'tenant_id', 'page_size', 'page', 'text_search', 'sort_property', 'sort_order', 'start_time', 'end_time']  # noqa: E501
         all_params.append('async_req')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
@@ -248,10 +264,14 @@ class EventControllerApi(object):
         if ('tenant_id' not in params or
                 params['tenant_id'] is None):
             raise ValueError("Missing the required parameter `tenant_id` when calling `get_events_using_get1`")  # noqa: E501
-        # verify the required parameter 'limit' is set
-        if ('limit' not in params or
-                params['limit'] is None):
-            raise ValueError("Missing the required parameter `limit` when calling `get_events_using_get1`")  # noqa: E501
+        # verify the required parameter 'page_size' is set
+        if ('page_size' not in params or
+                params['page_size'] is None):
+            raise ValueError("Missing the required parameter `page_size` when calling `get_events_using_get1`")  # noqa: E501
+        # verify the required parameter 'page' is set
+        if ('page' not in params or
+                params['page'] is None):
+            raise ValueError("Missing the required parameter `page` when calling `get_events_using_get1`")  # noqa: E501
 
         collection_formats = {}
 
@@ -264,16 +284,20 @@ class EventControllerApi(object):
         query_params = []
         if 'tenant_id' in params:
             query_params.append(('tenantId', params['tenant_id']))  # noqa: E501
-        if 'limit' in params:
-            query_params.append(('limit', params['limit']))  # noqa: E501
+        if 'page_size' in params:
+            query_params.append(('pageSize', params['page_size']))  # noqa: E501
+        if 'page' in params:
+            query_params.append(('page', params['page']))  # noqa: E501
+        if 'text_search' in params:
+            query_params.append(('textSearch', params['text_search']))  # noqa: E501
+        if 'sort_property' in params:
+            query_params.append(('sortProperty', params['sort_property']))  # noqa: E501
+        if 'sort_order' in params:
+            query_params.append(('sortOrder', params['sort_order']))  # noqa: E501
         if 'start_time' in params:
             query_params.append(('startTime', params['start_time']))  # noqa: E501
         if 'end_time' in params:
             query_params.append(('endTime', params['end_time']))  # noqa: E501
-        if 'asc_order' in params:
-            query_params.append(('ascOrder', params['asc_order']))  # noqa: E501
-        if 'offset' in params:
-            query_params.append(('offset', params['offset']))  # noqa: E501
 
         header_params = {}
 
@@ -293,7 +317,7 @@ class EventControllerApi(object):
         auth_settings = ['X-Authorization']  # noqa: E501
 
         return self.api_client.call_api(
-            '/api/events/{entityType}/{entityId}{?tenantId,limit,startTime,endTime,ascOrder,offset}', 'GET',
+            '/api/events/{entityType}/{entityId}{?tenantId,pageSize,page,textSearch,sortProperty,sortOrder,startTime,endTime}', 'GET',
             path_params,
             query_params,
             header_params,

--- a/tb_rest_client/api/api_ce/rule_chain_controller_api.py
+++ b/tb_rest_client/api/api_ce/rule_chain_controller_api.py
@@ -406,49 +406,51 @@ class RuleChainControllerApi(object):
             _request_timeout=params.get('_request_timeout'),
             collection_formats=collection_formats)
 
-    def get_rule_chains_using_get(self, limit, **kwargs):  # noqa: E501
+    def get_rule_chains_using_get(self, page_size, page, **kwargs):  # noqa: E501
         """getRuleChains  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
-        >>> thread = api_pe.get_rule_chains_using_get(limit, async_req=True)
+        >>> thread = api_pe.get_rule_chains_using_get(page_size, page, async_req=True)
         >>> result = thread.get()
 
         :param async_req bool
-        :param str limit: limit (required)
         :param str text_search: textSearch
-        :param str id_offset: idOffset
-        :param str text_offset: textOffset
+        :param str sort_property: sortProperty
+        :param str sort_order: sortOrder
+        :param str page_size: pageSize (required)
+        :param str page: page (required)
         :return: TextPageDataRuleChain
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
-            return self.get_rule_chains_using_get_with_http_info(limit, **kwargs)  # noqa: E501
+            return self.get_rule_chains_using_get_with_http_info(page_size, page, **kwargs)  # noqa: E501
         else:
-            (data) = self.get_rule_chains_using_get_with_http_info(limit, **kwargs)  # noqa: E501
+            (data) = self.get_rule_chains_using_get_with_http_info(page_size, page, **kwargs)  # noqa: E501
             return data
 
-    def get_rule_chains_using_get_with_http_info(self, limit, **kwargs):  # noqa: E501
+    def get_rule_chains_using_get_with_http_info(self, page_size, page, **kwargs):  # noqa: E501
         """getRuleChains  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
-        >>> thread = api_pe.get_rule_chains_using_get_with_http_info(limit, async_req=True)
+        >>> thread = api_pe.get_rule_chains_using_get_with_http_info(page_size, page, async_req=True)
         >>> result = thread.get()
 
         :param async_req bool
-        :param str limit: limit (required)
         :param str text_search: textSearch
-        :param str id_offset: idOffset
-        :param str text_offset: textOffset
+        :param str sort_property: sortProperty
+        :param str sort_order: sortOrder
+        :param str page_size: pageSize (required)
+        :param str page: page (required)
         :return: TextPageDataRuleChain
                  If the method is called asynchronously,
                  returns the request thread.
         """
 
-        all_params = ['limit', 'text_search', 'id_offset', 'text_offset']  # noqa: E501
+        all_params = ['text_search', 'sort_property', 'sort_order', 'page_size', 'page']  # noqa: E501
         all_params.append('async_req')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
@@ -459,10 +461,14 @@ class RuleChainControllerApi(object):
             
             params[key] = val
         del params['kwargs']
-        # verify the required parameter 'limit' is set
-        if ('limit' not in params or
-                params['limit'] is None):
-            raise ValueError("Missing the required parameter `limit` when calling `get_rule_chains_using_get`")  # noqa: E501
+        # verify the required parameter 'page_size' is set
+        if ('page_size' not in params or
+                params['page_size'] is None):
+            raise ValueError("Missing the required parameter `page_size` when calling `get_rule_chains_using_get`")  # noqa: E501
+        # verify the required parameter 'page' is set
+        if ('page' not in params or
+                params['page'] is None):
+            raise ValueError("Missing the required parameter `page` when calling `get_rule_chains_using_get`")  # noqa: E501
 
         collection_formats = {}
 
@@ -471,12 +477,14 @@ class RuleChainControllerApi(object):
         query_params = []
         if 'text_search' in params:
             query_params.append(('textSearch', params['text_search']))  # noqa: E501
-        if 'id_offset' in params:
-            query_params.append(('idOffset', params['id_offset']))  # noqa: E501
-        if 'text_offset' in params:
-            query_params.append(('textOffset', params['text_offset']))  # noqa: E501
-        if 'limit' in params:
-            query_params.append(('limit', params['limit']))  # noqa: E501
+        if 'sort_property' in params:
+            query_params.append(('sortProperty', params['sort_property']))  # noqa: E501
+        if 'sort_order' in params:
+            query_params.append(('sortOrder', params['sort_order']))  # noqa: E501
+        if 'page_size' in params:
+            query_params.append(('pageSize', params['page_size']))  # noqa: E501
+        if 'page' in params:
+            query_params.append(('page', params['page']))  # noqa: E501
 
         header_params = {}
 
@@ -496,7 +504,7 @@ class RuleChainControllerApi(object):
         auth_settings = ['X-Authorization']  # noqa: E501
 
         return self.api_client.call_api(
-            '/api/ruleChains{?textSearch,idOffset,textOffset,limit}', 'GET',
+            '/api/ruleChains{?textSearch,sortProperty,sortOrder,pageSize,page}', 'GET',
             path_params,
             query_params,
             header_params,

--- a/tb_rest_client/api/api_ce/tenant_controller_api.py
+++ b/tb_rest_client/api/api_ce/tenant_controller_api.py
@@ -220,49 +220,51 @@ class TenantControllerApi(object):
             _request_timeout=params.get('_request_timeout'),
             collection_formats=collection_formats)
 
-    def get_tenants_using_get(self, limit, **kwargs):  # noqa: E501
+    def get_tenants_using_get(self, page_size, page, **kwargs):  # noqa: E501
         """getTenants  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
-        >>> thread = api_pe.get_tenants_using_get(limit, async_req=True)
+        >>> thread = api_pe.get_tenants_using_get(page_size, page, async_req=True)
         >>> result = thread.get()
 
         :param async_req bool
-        :param str limit: limit (required)
         :param str text_search: textSearch
-        :param str id_offset: idOffset
-        :param str text_offset: textOffset
+        :param str sort_property: sortProperty
+        :param str sort_order: sortOrder
+        :param str page_size: pageSize (required)
+        :param str page: page (required)
         :return: TextPageDataTenant
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
-            return self.get_tenants_using_get_with_http_info(limit, **kwargs)  # noqa: E501
+            return self.get_tenants_using_get_with_http_info(page_size, page, **kwargs)  # noqa: E501
         else:
-            (data) = self.get_tenants_using_get_with_http_info(limit, **kwargs)  # noqa: E501
+            (data) = self.get_tenants_using_get_with_http_info(page_size, page, **kwargs)  # noqa: E501
             return data
 
-    def get_tenants_using_get_with_http_info(self, limit, **kwargs):  # noqa: E501
+    def get_tenants_using_get_with_http_info(self, page_size, page, **kwargs):  # noqa: E501
         """getTenants  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
-        >>> thread = api_pe.get_tenants_using_get_with_http_info(limit, async_req=True)
+        >>> thread = api_pe.get_tenants_using_get_with_http_info(page_size, page, async_req=True)
         >>> result = thread.get()
 
         :param async_req bool
-        :param str limit: limit (required)
         :param str text_search: textSearch
-        :param str id_offset: idOffset
-        :param str text_offset: textOffset
+        :param str sort_property: sortProperty
+        :param str sort_order: sortOrder
+        :param str page_size: pageSize (required)
+        :param str page: page (required)
         :return: TextPageDataTenant
                  If the method is called asynchronously,
                  returns the request thread.
         """
 
-        all_params = ['limit', 'text_search', 'id_offset', 'text_offset']  # noqa: E501
+        all_params = ['text_search', 'sort_property', 'sort_order', 'page_size', 'page']  # noqa: E501
         all_params.append('async_req')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
@@ -273,10 +275,14 @@ class TenantControllerApi(object):
             
             params[key] = val
         del params['kwargs']
-        # verify the required parameter 'limit' is set
-        if ('limit' not in params or
-                params['limit'] is None):
-            raise ValueError("Missing the required parameter `limit` when calling `get_tenants_using_get`")  # noqa: E501
+        # verify the required parameter 'page_size' is set
+        if ('page_size' not in params or
+                params['page_size'] is None):
+            raise ValueError("Missing the required parameter `page_size` when calling `get_tenants_using_get`")  # noqa: E501
+        # verify the required parameter 'page' is set
+        if ('page' not in params or
+                params['page'] is None):
+            raise ValueError("Missing the required parameter `page` when calling `get_tenants_using_get`")  # noqa: E501
 
         collection_formats = {}
 
@@ -285,12 +291,14 @@ class TenantControllerApi(object):
         query_params = []
         if 'text_search' in params:
             query_params.append(('textSearch', params['text_search']))  # noqa: E501
-        if 'id_offset' in params:
-            query_params.append(('idOffset', params['id_offset']))  # noqa: E501
-        if 'text_offset' in params:
-            query_params.append(('textOffset', params['text_offset']))  # noqa: E501
-        if 'limit' in params:
-            query_params.append(('limit', params['limit']))  # noqa: E501
+        if 'sort_property' in params:
+            query_params.append(('sortProperty', params['sort_property']))  # noqa: E501
+        if 'sort_order' in params:
+            query_params.append(('sortOrder', params['sort_order']))  # noqa: E501
+        if 'page_size' in params:
+            query_params.append(('pageSize', params['page_size']))  # noqa: E501
+        if 'page' in params:
+            query_params.append(('page', params['page']))  # noqa: E501
 
         header_params = {}
 
@@ -310,7 +318,7 @@ class TenantControllerApi(object):
         auth_settings = ['X-Authorization']  # noqa: E501
 
         return self.api_client.call_api(
-            '/api/tenants{?textSearch,idOffset,textOffset,limit}', 'GET',
+            '/api/tenants{?textSearch,sortProperty,sortOrder,pageSize,page}', 'GET',
             path_params,
             query_params,
             header_params,

--- a/tb_rest_client/api/api_ce/user_controller_api.py
+++ b/tb_rest_client/api/api_ce/user_controller_api.py
@@ -317,51 +317,53 @@ class UserControllerApi(object):
             _request_timeout=params.get('_request_timeout'),
             collection_formats=collection_formats)
 
-    def get_customer_users_using_get(self, customer_id, limit, **kwargs):  # noqa: E501
+    def get_customer_users_using_get(self, customer_id, page_size, page, **kwargs):  # noqa: E501
         """getCustomerUsers  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
-        >>> thread = api_pe.get_customer_users_using_get(customer_id, limit, async_req=True)
+        >>> thread = api_pe.get_customer_users_using_get(customer_id, page_size, page, async_req=True)
         >>> result = thread.get()
 
         :param async_req bool
         :param str customer_id: customerId (required)
-        :param str limit: limit (required)
         :param str text_search: textSearch
-        :param str id_offset: idOffset
-        :param str text_offset: textOffset
+        :param str sort_property: sortProperty
+        :param str sort_order: sortOrder
+        :param str page_size: pageSize (required)
+        :param str page: page (required)
         :return: TextPageDataUser
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
-            return self.get_customer_users_using_get_with_http_info(customer_id, limit, **kwargs)  # noqa: E501
+            return self.get_customer_users_using_get_with_http_info(customer_id, page_size, page, **kwargs)  # noqa: E501
         else:
-            (data) = self.get_customer_users_using_get_with_http_info(customer_id, limit, **kwargs)  # noqa: E501
+            (data) = self.get_customer_users_using_get_with_http_info(customer_id, page_size, page, **kwargs)  # noqa: E501
             return data
 
-    def get_customer_users_using_get_with_http_info(self, customer_id, limit, **kwargs):  # noqa: E501
+    def get_customer_users_using_get_with_http_info(self, customer_id, page_size, page, **kwargs):  # noqa: E501
         """getCustomerUsers  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
-        >>> thread = api_pe.get_customer_users_using_get_with_http_info(customer_id, limit, async_req=True)
+        >>> thread = api_pe.get_customer_users_using_get_with_http_info(customer_id, page_size, page, async_req=True)
         >>> result = thread.get()
 
         :param async_req bool
         :param str customer_id: customerId (required)
-        :param str limit: limit (required)
         :param str text_search: textSearch
-        :param str id_offset: idOffset
-        :param str text_offset: textOffset
+        :param str sort_property: sortProperty
+        :param str sort_order: sortOrder
+        :param str page_size: pageSize (required)
+        :param str page: page (required)
         :return: TextPageDataUser
                  If the method is called asynchronously,
                  returns the request thread.
         """
 
-        all_params = ['customer_id', 'limit', 'text_search', 'id_offset', 'text_offset']  # noqa: E501
+        all_params = ['customer_id', 'text_search', 'sort_property', 'sort_order', 'page_size', 'page']  # noqa: E501
         all_params.append('async_req')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
@@ -376,10 +378,14 @@ class UserControllerApi(object):
         if ('customer_id' not in params or
                 params['customer_id'] is None):
             raise ValueError("Missing the required parameter `customer_id` when calling `get_customer_users_using_get`")  # noqa: E501
-        # verify the required parameter 'limit' is set
-        if ('limit' not in params or
-                params['limit'] is None):
-            raise ValueError("Missing the required parameter `limit` when calling `get_customer_users_using_get`")  # noqa: E501
+        # verify the required parameter 'page_size' is set
+        if ('page_size' not in params or
+                params['page_size'] is None):
+            raise ValueError("Missing the required parameter `page_size` when calling `get_customer_users_using_get`")  # noqa: E501
+        # verify the required parameter 'page' is set
+        if ('page' not in params or
+                params['page'] is None):
+            raise ValueError("Missing the required parameter `page` when calling `get_customer_users_using_get`")  # noqa: E501
 
         collection_formats = {}
 
@@ -390,12 +396,14 @@ class UserControllerApi(object):
         query_params = []
         if 'text_search' in params:
             query_params.append(('textSearch', params['text_search']))  # noqa: E501
-        if 'id_offset' in params:
-            query_params.append(('idOffset', params['id_offset']))  # noqa: E501
-        if 'text_offset' in params:
-            query_params.append(('textOffset', params['text_offset']))  # noqa: E501
-        if 'limit' in params:
-            query_params.append(('limit', params['limit']))  # noqa: E501
+        if 'sort_property' in params:
+            query_params.append(('sortProperty', params['sort_property']))  # noqa: E501
+        if 'sort_order' in params:
+            query_params.append(('sortOrder', params['sort_order']))  # noqa: E501
+        if 'page_size' in params:
+            query_params.append(('pageSize', params['page_size']))  # noqa: E501
+        if 'page' in params:
+            query_params.append(('page', params['page']))  # noqa: E501
 
         header_params = {}
 
@@ -415,7 +423,7 @@ class UserControllerApi(object):
         auth_settings = ['X-Authorization']  # noqa: E501
 
         return self.api_client.call_api(
-            '/api/customer/{customerId}/users{?textSearch,idOffset,textOffset,limit}', 'GET',
+            '/api/customer/{customerId}/users{?textSearch,sortProperty,sortOrder,pageSize,page}', 'GET',
             path_params,
             query_params,
             header_params,
@@ -430,51 +438,53 @@ class UserControllerApi(object):
             _request_timeout=params.get('_request_timeout'),
             collection_formats=collection_formats)
 
-    def get_tenant_admins_using_get(self, tenant_id, limit, **kwargs):  # noqa: E501
+    def get_tenant_admins_using_get(self, tenant_id, page_size, page, **kwargs):  # noqa: E501
         """getTenantAdmins  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
-        >>> thread = api_pe.get_tenant_admins_using_get(tenant_id, limit, async_req=True)
+        >>> thread = api_pe.get_tenant_admins_using_get(tenant_id, page_size, page, async_req=True)
         >>> result = thread.get()
 
         :param async_req bool
         :param str tenant_id: tenantId (required)
-        :param str limit: limit (required)
         :param str text_search: textSearch
-        :param str id_offset: idOffset
-        :param str text_offset: textOffset
+        :param str sort_property: sortProperty
+        :param str sort_order: sortOrder
+        :param str page_size: pageSize (required)
+        :param str page: page (required)
         :return: TextPageDataUser
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
-            return self.get_tenant_admins_using_get_with_http_info(tenant_id, limit, **kwargs)  # noqa: E501
+            return self.get_tenant_admins_using_get_with_http_info(tenant_id, page_size, page, **kwargs)  # noqa: E501
         else:
-            (data) = self.get_tenant_admins_using_get_with_http_info(tenant_id, limit, **kwargs)  # noqa: E501
+            (data) = self.get_tenant_admins_using_get_with_http_info(tenant_id, page_size, page, **kwargs)  # noqa: E501
             return data
 
-    def get_tenant_admins_using_get_with_http_info(self, tenant_id, limit, **kwargs):  # noqa: E501
+    def get_tenant_admins_using_get_with_http_info(self, tenant_id, page_size, page, **kwargs):  # noqa: E501
         """getTenantAdmins  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
-        >>> thread = api_pe.get_tenant_admins_using_get_with_http_info(tenant_id, limit, async_req=True)
+        >>> thread = api_pe.get_tenant_admins_using_get_with_http_info(tenant_id, page_size, page, async_req=True)
         >>> result = thread.get()
 
         :param async_req bool
         :param str tenant_id: tenantId (required)
-        :param str limit: limit (required)
         :param str text_search: textSearch
-        :param str id_offset: idOffset
-        :param str text_offset: textOffset
+        :param str sort_property: sortProperty
+        :param str sort_order: sortOrder
+        :param str page_size: pageSize (required)
+        :param str page: page (required)
         :return: TextPageDataUser
                  If the method is called asynchronously,
                  returns the request thread.
         """
 
-        all_params = ['tenant_id', 'limit', 'text_search', 'id_offset', 'text_offset']  # noqa: E501
+        all_params = ['tenant_id', 'text_search', 'sort_property', 'sort_order', 'page_size', 'page']  # noqa: E501
         all_params.append('async_req')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
@@ -489,10 +499,14 @@ class UserControllerApi(object):
         if ('tenant_id' not in params or
                 params['tenant_id'] is None):
             raise ValueError("Missing the required parameter `tenant_id` when calling `get_tenant_admins_using_get`")  # noqa: E501
-        # verify the required parameter 'limit' is set
-        if ('limit' not in params or
-                params['limit'] is None):
-            raise ValueError("Missing the required parameter `limit` when calling `get_tenant_admins_using_get`")  # noqa: E501
+        # verify the required parameter 'page_size' is set
+        if ('page_size' not in params or
+                params['page_size'] is None):
+            raise ValueError("Missing the required parameter `page_size` when calling `get_tenant_admins_using_get`")  # noqa: E501
+        # verify the required parameter 'page' is set
+        if ('page' not in params or
+                params['page'] is None):
+            raise ValueError("Missing the required parameter `page` when calling `get_tenant_admins_using_get`")  # noqa: E501
 
         collection_formats = {}
 
@@ -503,12 +517,14 @@ class UserControllerApi(object):
         query_params = []
         if 'text_search' in params:
             query_params.append(('textSearch', params['text_search']))  # noqa: E501
-        if 'id_offset' in params:
-            query_params.append(('idOffset', params['id_offset']))  # noqa: E501
-        if 'text_offset' in params:
-            query_params.append(('textOffset', params['text_offset']))  # noqa: E501
-        if 'limit' in params:
-            query_params.append(('limit', params['limit']))  # noqa: E501
+        if 'sort_property' in params:
+            query_params.append(('sortProperty', params['sort_property']))  # noqa: E501
+        if 'sort_order' in params:
+            query_params.append(('sortOrder', params['sort_order']))  # noqa: E501
+        if 'page_size' in params:
+            query_params.append(('pageSize', params['page_size']))  # noqa: E501
+        if 'page' in params:
+            query_params.append(('page', params['page']))  # noqa: E501
 
         header_params = {}
 
@@ -528,7 +544,7 @@ class UserControllerApi(object):
         auth_settings = ['X-Authorization']  # noqa: E501
 
         return self.api_client.call_api(
-            '/api/tenant/{tenantId}/users{?textSearch,idOffset,textOffset,limit}', 'GET',
+            '/api/tenant/{tenantId}/users{?textSearch,sortProperty,sortOrder,pageSize,page}', 'GET',
             path_params,
             query_params,
             header_params,

--- a/tb_rest_client/api/api_ce/widgets_bundle_controller_api.py
+++ b/tb_rest_client/api/api_ce/widgets_bundle_controller_api.py
@@ -220,49 +220,51 @@ class WidgetsBundleControllerApi(object):
             _request_timeout=params.get('_request_timeout'),
             collection_formats=collection_formats)
 
-    def get_widgets_bundles_using_get(self, limit, **kwargs):  # noqa: E501
+    def get_widgets_bundles_using_get(self, page_size, page, **kwargs):  # noqa: E501
         """getWidgetsBundles  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
-        >>> thread = api_pe.get_widgets_bundles_using_get(limit, async_req=True)
+        >>> thread = api_pe.get_widgets_bundles_using_get(page_size, page, async_req=True)
         >>> result = thread.get()
 
         :param async_req bool
-        :param str limit: limit (required)
         :param str text_search: textSearch
-        :param str id_offset: idOffset
-        :param str text_offset: textOffset
+        :param str sort_property: sortProperty
+        :param str sort_order: sortOrder
+        :param str page_size: pageSize (required)
+        :param str page: page (required)
         :return: TextPageDataWidgetsBundle
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
-            return self.get_widgets_bundles_using_get_with_http_info(limit, **kwargs)  # noqa: E501
+            return self.get_widgets_bundles_using_get_with_http_info(page_size, page, **kwargs)  # noqa: E501
         else:
-            (data) = self.get_widgets_bundles_using_get_with_http_info(limit, **kwargs)  # noqa: E501
+            (data) = self.get_widgets_bundles_using_get_with_http_info(page_size, page, **kwargs)  # noqa: E501
             return data
 
-    def get_widgets_bundles_using_get_with_http_info(self, limit, **kwargs):  # noqa: E501
+    def get_widgets_bundles_using_get_with_http_info(self, page_size, page, **kwargs):  # noqa: E501
         """getWidgetsBundles  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
-        >>> thread = api_pe.get_widgets_bundles_using_get_with_http_info(limit, async_req=True)
+        >>> thread = api_pe.get_widgets_bundles_using_get_with_http_info(page_size, page, async_req=True)
         >>> result = thread.get()
 
         :param async_req bool
-        :param str limit: limit (required)
         :param str text_search: textSearch
-        :param str id_offset: idOffset
-        :param str text_offset: textOffset
+        :param str sort_property: sortProperty
+        :param str sort_order: sortOrder
+        :param str page_size: pageSize (required)
+        :param str page: page (required)
         :return: TextPageDataWidgetsBundle
                  If the method is called asynchronously,
                  returns the request thread.
         """
 
-        all_params = ['limit', 'text_search', 'id_offset', 'text_offset']  # noqa: E501
+        all_params = ['text_search', 'sort_property', 'sort_order', 'page_size', 'page']  # noqa: E501
         all_params.append('async_req')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
@@ -273,10 +275,10 @@ class WidgetsBundleControllerApi(object):
             
             params[key] = val
         del params['kwargs']
-        # verify the required parameter 'limit' is set
-        if ('limit' not in params or
-                params['limit'] is None):
-            raise ValueError("Missing the required parameter `limit` when calling `get_widgets_bundles_using_get`")  # noqa: E501
+        # verify the required parameter 'page_size' is set
+        if ('page_size' not in params or
+                params['page_size'] is None):
+            raise ValueError("Missing the required parameter `page_size` when calling `get_widgets_bundles_using_get`")  # noqa: E501
 
         collection_formats = {}
 
@@ -285,12 +287,14 @@ class WidgetsBundleControllerApi(object):
         query_params = []
         if 'text_search' in params:
             query_params.append(('textSearch', params['text_search']))  # noqa: E501
-        if 'id_offset' in params:
-            query_params.append(('idOffset', params['id_offset']))  # noqa: E501
-        if 'text_offset' in params:
-            query_params.append(('textOffset', params['text_offset']))  # noqa: E501
-        if 'limit' in params:
-            query_params.append(('limit', params['limit']))  # noqa: E501
+        if 'sort_property' in params:
+            query_params.append(('sortProperty', params['sort_property']))  # noqa: E501
+        if 'sort_order' in params:
+            query_params.append(('sortOrder', params['sort_order']))  # noqa: E501
+        if 'page_size' in params:
+            query_params.append(('pageSize', params['page_size']))  # noqa: E501
+        if 'page' in params:
+            query_params.append(('page', params['page']))  # noqa: E501
 
         header_params = {}
 
@@ -310,7 +314,7 @@ class WidgetsBundleControllerApi(object):
         auth_settings = ['X-Authorization']  # noqa: E501
 
         return self.api_client.call_api(
-            '/api/widgetsBundles{?textSearch,idOffset,textOffset,limit}', 'GET',
+            '/api/widgetsBundles{?textSearch,sortProperty,sortOrder,pageSize,page}', 'GET',
             path_params,
             query_params,
             header_params,

--- a/tb_rest_client/rest_client_base.py
+++ b/tb_rest_client/rest_client_base.py
@@ -154,7 +154,7 @@ class RestClientBase(Thread):
         asset_id = self.get_id(asset_id)
         return self.asset_controller.delete_asset_using_delete(asset_id)
 
-    def get_tenant_assets(self, type=None, page_size=10, page=0, text_search=None, sort_property=None, sort_order=None,
+    def get_tenant_assets(self, page_size=10, page=0, type=None, text_search=None, sort_property=None, sort_order=None,
                           limit=100000):
         return self.asset_controller.get_tenant_assets_using_get(page_size=str(page_size),
                                                                  page=str(page),
@@ -166,7 +166,7 @@ class RestClientBase(Thread):
     def get_tenant_asset(self, asset_name):
         return self.asset_controller.get_tenant_asset_using_get(asset_name)
 
-    def get_customer_assets(self, customer_id: CustomerId, type, page_size=10, page=0, text_search=None,
+    def get_customer_assets(self, customer_id: CustomerId, page_size=10, page=0, type=None, text_search=None,
                             sort_property=None, sort_order=None, limit=100000):
         customer_id = self.get_id(customer_id)
         return self.asset_controller.get_customer_assets_using_get(customer_id=customer_id,
@@ -392,7 +392,7 @@ class RestClientBase(Thread):
     def get_tenant_device(self, device_name):
         return self.device_controller.get_tenant_device_using_get(device_name)
 
-    def get_customer_devices(self, customer_id: CustomerId, type=None, page_size=None, page=None, text_search=None,
+    def get_customer_devices(self, customer_id: CustomerId, page_size=None, page=None, type=None, text_search=None,
                              sort_property=None, sort_order=None, limit=100000):
         customer_id = self.get_id(customer_id)
         return self.device_controller.get_customer_devices_using_get(customer_id=customer_id,
@@ -498,7 +498,7 @@ class RestClientBase(Thread):
     def get_tenant_entity_view(self, entity_view_name):
         return self.entity_view_controller.get_tenant_entity_view_using_get(entity_view_name=entity_view_name)
 
-    def get_customer_entity_views(self, customer_id: CustomerId, type=None, page_size=10, page=0, text_search=None,
+    def get_customer_entity_views(self, customer_id: CustomerId, page_size=10, page=0, type=None, text_search=None,
                                   sort_property=None, sort_order=None, limit=100000):
         customer_id = self.get_id(customer_id)
         return self.entity_view_controller.get_customer_entity_views_using_get(customer_id=customer_id,


### PR DESCRIPTION
Hi,

This MR is to update the community version of the 'tb-rest-client' to be more compatible with the Thingsboard version 3.1 REST API with regards to the limit/page_size/page difference between TB 2.x and TB 3.x.

As there most likely is a lot of different versions of Thingsboard running, maybe the client should come for different Thingsboard versions?